### PR TITLE
feat: add canvas blob fallback for ios

### DIFF
--- a/code.html
+++ b/code.html
@@ -1601,30 +1601,31 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
   }
 
   // ---------- безопасное получение blob ----------
-  function canvasToBlobSafe(canvas, mime="image/png", quality=0.92) {
+  function dataURLToBlob(dataURL, mime) {
+    const bstr = atob(dataURL.split(',')[1]);
+    const len = bstr.length;
+    const u8 = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      u8[i] = bstr.charCodeAt(i);
+    }
+    return new Blob([u8], { type: mime });
+  }
+
+  function canvasToBlobSafe(canvas, mime = "image/png", quality = 0.92) {
     return new Promise((resolve, reject) => {
       if (!canvas.toBlob) {
         try {
-          const dataURL = canvas.toDataURL(mime, quality);
-          const bstr = atob(dataURL.split(',')[1]);
-          const len = bstr.length;
-          const u8 = new Uint8Array(len);
-          for (let i = 0; i < len; i++) u8[i] = bstr.charCodeAt(i);
-          return resolve(new Blob([u8], { type: mime }));
+          return resolve(dataURLToBlob(canvas.toDataURL(mime, quality), mime));
         } catch (e) {
           return reject(e);
         }
       }
       canvas.toBlob(b => {
-        if (b) resolve(b);
-        else {
+        if (b) {
+          resolve(b);
+        } else {
           try {
-            const dataURL = canvas.toDataURL(mime, quality);
-            const bstr = atob(dataURL.split(',')[1]);
-            const len = bstr.length;
-            const u8 = new Uint8Array(len);
-            for (let i = 0; i < len; i++) u8[i] = bstr.charCodeAt(i);
-            resolve(new Blob([u8], { type: mime }));
+            resolve(dataURLToBlob(canvas.toDataURL(mime, quality), mime));
           } catch (e) {
             reject(new Error("toBlob/toDataURL failed"));
           }

--- a/code.html
+++ b/code.html
@@ -1482,9 +1482,7 @@
         </div>
         <script>
         
-            const GAS_URL = "https://script.google.com/macros/s/AKfycbylXNq9oJrGn4NQC4hc7S2YJmVo9fPv6IQrPzCi0u2GzOn88vj3nHbi_JaFh-sApsCD/exec";
-const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
-                 (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+const GAS_URL = "https://script.google.com/macros/s/AKfycbylXNq9oJrGn4NQC4hc7S2YJmVo9fPv6IQrPzCi0u2GzOn88vj3nHbi_JaFh-sApsCD/exec";
 
   function nowStamp() {
     const d = new Date();
@@ -1524,9 +1522,8 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
     return [...urls];
   }
 
-  // На iOS переводим background-image:url(...) → data:... (чтобы точно не таинтилось)
+  // Переводим background-image:url(...) → data:..., чтобы canvas не таинтился
   async function inlineBackgrounds(root) {
-    if (!IS_IOS) return { changed: [], restore(){} };
 
     const changed = [];
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, null);
@@ -1591,9 +1588,8 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
     };
   }
 
-  // На iOS инлайним <img src> → data:...
+  // Инлайним <img src> → data:..., чтобы избежать CORS-проблем
   async function inlineImages(root) {
-    if (!IS_IOS) return { changed: [], restore(){} };
 
     const changed = [];
     const imgs = root.querySelectorAll("img");
@@ -1638,11 +1634,8 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
 
   async function ensureFontsAndImagesReady(root) {
     await ensureFontsReady();
-    // для не-iOS просто прелоадим внешние фоновые картинки
-    if (!IS_IOS) {
-      const urls = collectBgUrls(root);
-      if (urls.length) await preloadImgs(urls);
-    }
+    const urls = collectBgUrls(root);
+    if (urls.length) await preloadImgs(urls);
   }
 
   // ---------- безопасное получение blob ----------
@@ -1680,7 +1673,7 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
   }
 
   async function captureElement(el) {
-    // 1) инлайн ресурсы на iOS
+    // 1) инлайн внешние ресурсы
     const inlinedBg = await inlineBackgrounds(el);
     const inlinedImg = await inlineImages(el);
     try {
@@ -1689,7 +1682,7 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
 
       // 3) сам захват
       const canvas = await html2canvas(el, {
-        scale: IS_IOS ? 1 : Math.min(window.devicePixelRatio || 1, 2),
+        scale: Math.min(window.devicePixelRatio || 1, 2),
         useCORS: true,
         allowTaint: false,
         backgroundColor: null,
@@ -1793,7 +1786,6 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
               textSpan.textContent = loadText + ".".repeat(dots);
             }, 500);
 
-            const delay = IS_IOS ? 300 : 50;
             setTimeout(() => {
               makeScreenshotAndSend(function(fileUrl) {
                 clearInterval(intervalId);
@@ -1806,7 +1798,7 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
                   submitButton.style.pointerEvents = "none";
                 }
               });
-            }, delay);
+            }, 100);
           }
         }
       });

--- a/code.html
+++ b/code.html
@@ -1591,6 +1591,51 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
     };
   }
 
+  // На iOS инлайним <img src> → data:...
+  async function inlineImages(root) {
+    if (!IS_IOS) return { changed: [], restore(){} };
+
+    const changed = [];
+    const imgs = root.querySelectorAll("img");
+    const cache = new Map();
+
+    async function toDataUrl(url) {
+      if (cache.has(url)) return cache.get(url);
+      const resp = await fetch(url, { mode: "cors" });
+      const blob = await resp.blob();
+      const dataUrl = await new Promise(r => {
+        const fr = new FileReader();
+        fr.onloadend = () => r(fr.result);
+        fr.readAsDataURL(blob);
+      });
+      cache.set(url, dataUrl);
+      return dataUrl;
+    }
+
+    const tasks = Array.from(imgs).map(async img => {
+      const src = img.getAttribute("src");
+      if (!src || src.startsWith("data:")) return;
+      try {
+        const data = await toDataUrl(src);
+        img.setAttribute("src", data);
+        changed.push({ img, src });
+      } catch (e) {
+        // пропускаем, если не удалось
+      }
+    });
+
+    await Promise.all(tasks);
+
+    return {
+      changed,
+      restore() {
+        for (const { img, src } of changed) {
+          img.setAttribute("src", src);
+        }
+      }
+    };
+  }
+
   async function ensureFontsAndImagesReady(root) {
     await ensureFontsReady();
     // для не-iOS просто прелоадим внешние фоновые картинки
@@ -1635,8 +1680,9 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
   }
 
   async function captureElement(el) {
-    // 1) инлайн фоны на iOS
-    const inlined = await inlineBackgrounds(el);
+    // 1) инлайн ресурсы на iOS
+    const inlinedBg = await inlineBackgrounds(el);
+    const inlinedImg = await inlineImages(el);
     try {
       // 2) дождаться шрифтов/картинок
       await ensureFontsAndImagesReady(el);
@@ -1655,8 +1701,9 @@ const IS_IOS = /iP(ad|hone|od)/.test(navigator.userAgent) ||
       // 4) blob + двойной fallback
       return await canvasToBlobSafe(canvas, "image/png", 0.9);
     } finally {
-      // 5) вернуть исходные background-image
-      inlined.restore?.();
+      // 5) вернуть исходные ресурсы
+      inlinedBg.restore?.();
+      inlinedImg.restore?.();
     }
   }
 


### PR DESCRIPTION
## Summary
- add helper to convert data URL to Blob
- use helper in `canvasToBlobSafe` for reliable screenshot uploading on iOS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aacf726a0c8328b2149957b456f214